### PR TITLE
Fixed strlen warning

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -29,9 +29,9 @@ function parcelshop_html()
     $tmpEnvironment = new \Wuunder\Api\Environment(get_option('wc_wuunder_api_status') === 'staging' ? 'staging' : 'production');
 
     $baseApiUrl = substr($tmpEnvironment->getStageBaseUrl(), 0, -3);
-    $carrierList = get_option('woocommerce_wuunder_parcelshop_settings')['select_carriers'];
+    $carrierList = implode(',', get_option('woocommerce_wuunder_parcelshop_settings')['select_carriers']);
     if ( 0 !== strlen($carrierList)  ) {
-        $availableCarriers = implode(',', $carrierList);
+        $availableCarriers = $carrierList;
     } else {
         $availableCarriers = implode(',', array_keys(get_option('default_carrier_list')));
     }


### PR DESCRIPTION
Warning on checkout page. Strlen expects string not array. I changed it so that the var is imploded before running strlen function.