### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Released 
 
+## [2.7.20](https://github.com/wuunder/wuunder-webshopplugin-woocommerce/tag/2.7.20) - 2020-12-11
+
+### Fixed
+
+- Fix hook used for webhook processing
+
 ## [2.7.19](https://github.com/wuunder/wuunder-webshopplugin-woocommerce/tag/2.7.19) - 2020-07-02
 
 ### Added

--- a/includes/wcwuunder-create.php
+++ b/includes/wcwuunder-create.php
@@ -137,7 +137,9 @@ if (!class_exists('WC_Wuunder_Create')) {
             $bookingConfig->setHeight($this->wcwp_roundButNull($dimensions[2]));
             $bookingConfig->setWeight($totalWeight ? $totalWeight : null);
             $bookingConfig->setCustomerReference($orderId);
-            $bookingConfig->setPreferredServiceLevel((count($order->get_items('shipping')) > 0) ? $this->wcwp_get_filter_from_shippingmethod(reset($order->get_items('shipping'))->get_method_id()) : '');
+
+            $order_items = $order->get_items('shipping');
+            $bookingConfig->setPreferredServiceLevel((count($order->get_items('shipping')) > 0) ? $this->wcwp_get_filter_from_shippingmethod(reset($order_items)->get_method_id()) : '');
             $bookingConfig->setSource($this->version_obj);
 
             $orderMeta = get_post_meta($orderId);

--- a/includes/wcwuunder-create.php
+++ b/includes/wcwuunder-create.php
@@ -13,7 +13,7 @@ if (!class_exists('WC_Wuunder_Create')) {
             $this->version_obj = array(
                 'product' => 'Woocommerce extension',
                 'version' => array(
-                    'build' => '2.7.19',
+                    'build' => '2.7.20',
                     'plugin' => '2.0'),
                 'platform' => array(
                     'name' => 'Woocommerce',

--- a/includes/wcwuunder-create.php
+++ b/includes/wcwuunder-create.php
@@ -410,7 +410,7 @@ if (!class_exists('WC_Wuunder_Create')) {
                     <a
                         <?php
                         echo $target; ?>href=" <?php echo $data['url']; ?>"
-                        class="<?php echo $data['action']; ?> button tips <?php echo $action; ?>"
+                        class="<?php echo $action; ?> button tips <?php echo $action; ?>"
                         style="background:#8dcc00; height:2em; width:2em; padding:3px;"
                         alt="<?php echo $data['title']; ?>" data-tip="<?php echo $data['title']; ?>">
                         <img src="<?php echo $data['img']; ?>" style="width:18px; margin: 4px 3px;"

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,8 @@ You can best contact us via info@wearewuunder.com
 7. Eenvoudig labels printen
 
 == Changelog ==
+= 2.7.20 =
+* Fix hook used for webhook processing
 = 2.7.19 =
 * Fix rparcelshop error
 * Added support for multi-site Wordpress

--- a/woocommerce-wuunder.php
+++ b/woocommerce-wuunder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Wuunder for-woocommerce
  * Plugin URI: https://wearewuunder.com/wuunder-voor-webshops/
  * Description: Wuunder shipping plugin
- * Version: 2.7.19
+ * Version: 2.7.20
  * Author: Wuunder
  * Author URI: http://wearewuunder.com
  */
@@ -57,7 +57,7 @@ if ( !class_exists( 'Woocommerce_Wuunder' ) ) {
         public static $plugin_path;
         public static $plugin_basename;
 
-        const VERSION = '2.7.19';
+        const VERSION = '2.7.20';
 
         public function __construct() {
 


### PR DESCRIPTION
- Fix for processing webhooks. Seems post types are not always registered when hooking into "wp_loaded" hook. Now using "init" hook with priority value "20". This seems to fix it.